### PR TITLE
Platform-specific build command

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,0 +1,12 @@
+const os = require('os');
+const exec = require('child_process').exec;
+
+var env = 'NODE_ENV=production'
+var buildCmd = 'babel src --out-dir lib';
+if (os.type() === 'Windows_NT') {
+  buildCmd = 'set ' + env + '&&' + buildCmd;
+} else {
+  buildCmd = env + ' ' + buildCmd;
+}
+exec(buildCmd);
+

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "clean": "rimraf lib",
     "start": "NODE_ENV=development node webpack.server.development.js",
-    "build": "NODE_ENV=production babel src --out-dir lib",
+    "build": "node build.js",
     "lint": "eslint --ext .jsx --ext .js src example",
     "test": "npm run lint",
     "precommit": "npm test",


### PR DESCRIPTION
To allow this package to be installed on Win platform, I have created a specific build script that appends set command before environmental variable on windows (also adds additional '&&' _without spaces_ to separate it from main build command.
